### PR TITLE
Initialize WorldFork Core prototype (Fastify + Prisma + diff/merge + APIs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,108 @@
+# WorldFork Core (v0.1)
+
+WorldFork Core 是一个最小闭环原型：建世界 → 写 Unit → 提交 → 分支 → Diff → Merge/冲突 → Merge Commit。
+
+## 设计说明
+
+- **快照存储**：每次提交都会把当前分支的全部 Unit 状态写入 `UnitSnapshot`，保证提交不可变、可重复读取。
+- **工作区**：分支维护 `UnitState` 作为当前工作区，提交时从 `UnitState` 生成快照。
+- **Diff**：字段级结构对比，输出 JSON Pointer 风格 `path`。
+- **Merge**：三方合并（base/ours/theirs）。
+  - 若 `ours == base`，采用 `theirs`；若 `theirs == base`，采用 `ours`。
+  - 其它情况视为冲突，返回 `conflicts`。
+  - 冲突解决只支持 `ours/theirs/manual`，不做语义理解。
+
+## 开始使用
+
+```bash
+npm i
+npm run prisma:generate
+npm run dev
+```
+
+默认使用 SQLite（`prisma/dev.db`）。
+
+## API 演示流程（可直接复制）
+
+> 请先启动服务：`npm run dev`
+
+```bash
+# 1) 创建世界
+WORLD_ID=$(curl -s -X POST http://localhost:3000/v1/worlds \
+  -H 'content-type: application/json' \
+  -d '{"name":"Demo World","description":"v0.1"}' | jq -r '.id')
+
+echo "WORLD_ID=$WORLD_ID"
+
+# 2) main 分支创建 Unit 并提交
+UNIT_ID=$(curl -s -X POST http://localhost:3000/v1/worlds/$WORLD_ID/units \
+  -H 'content-type: application/json' \
+  -d '{"branchName":"main","unit":{"type":"npc","title":"Guard","fields":{"hp":10,"role":"watcher"}}}' | jq -r '.id')
+
+echo "UNIT_ID=$UNIT_ID"
+
+curl -s -X POST http://localhost:3000/v1/worlds/$WORLD_ID/commits \
+  -H 'content-type: application/json' \
+  -d '{"branchName":"main","message":"initial guard"}' | jq
+
+# 3) 从 main 分支创建新分支 alt
+curl -s -X POST http://localhost:3000/v1/worlds/$WORLD_ID/branches \
+  -H 'content-type: application/json' \
+  -d '{"name":"alt","sourceBranch":"main"}' | jq
+
+# 4) alt 修改 unit 并提交
+curl -s -X POST http://localhost:3000/v1/worlds/$WORLD_ID/units \
+  -H 'content-type: application/json' \
+  -d '{"branchName":"alt","unit":{"id":"'"$UNIT_ID"'","type":"npc","title":"Guard (Alt)","fields":{"hp":8,"role":"watcher"}}}' | jq
+
+curl -s -X POST http://localhost:3000/v1/worlds/$WORLD_ID/commits \
+  -H 'content-type: application/json' \
+  -d '{"branchName":"alt","message":"alt tweak"}' | jq
+
+# 5) main 也修改 unit 并提交（制造冲突）
+curl -s -X POST http://localhost:3000/v1/worlds/$WORLD_ID/units \
+  -H 'content-type: application/json' \
+  -d '{"branchName":"main","unit":{"id":"'"$UNIT_ID"'","type":"npc","title":"Guard (Main)","fields":{"hp":10,"role":"captain"}}}' | jq
+
+curl -s -X POST http://localhost:3000/v1/worlds/$WORLD_ID/commits \
+  -H 'content-type: application/json' \
+  -d '{"branchName":"main","message":"main tweak"}' | jq
+
+# 6) diff 分支
+curl -s "http://localhost:3000/v1/worlds/$WORLD_ID/diff?from=branch:main&to=branch:alt" | jq
+
+# 7) merge（首次会返回 conflicts + preview）
+MERGE_PREVIEW=$(curl -s -X POST http://localhost:3000/v1/worlds/$WORLD_ID/merge \
+  -H 'content-type: application/json' \
+  -d '{"oursBranch":"main","theirsBranch":"alt"}')
+
+echo "$MERGE_PREVIEW" | jq
+
+# 8) 解决冲突（示例：title 取 theirs，role 手工指定）
+MERGE_COMMIT=$(curl -s -X POST http://localhost:3000/v1/worlds/$WORLD_ID/merge \
+  -H 'content-type: application/json' \
+  -d '{
+    "oursBranch":"main",
+    "theirsBranch":"alt",
+    "resolutions":[
+      {"unitId":"'"$UNIT_ID"'","path":"/title","choice":"theirs"},
+      {"unitId":"'"$UNIT_ID"'","path":"/fields/role","choice":"manual","value":"lieutenant"}
+    ]
+  }' | jq -r '.mergeCommitId')
+
+echo "MERGE_COMMIT=$MERGE_COMMIT"
+```
+
+## 错误格式
+
+所有错误统一返回：
+
+```json
+{
+  "error": {
+    "code": "INVALID_INPUT",
+    "message": "Invalid request",
+    "details": {}
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "worldfork-core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "prisma:migrate": "prisma migrate dev --name init",
+    "prisma:generate": "prisma generate"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.19.1",
+    "fastify": "^4.28.1",
+    "nanoid": "^5.0.7",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "prisma": "^5.19.1",
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.3",
+    "vitest": "^1.6.0"
+  }
+}

--- a/prisma/migrations/20250101000000_init/migration.sql
+++ b/prisma/migrations/20250101000000_init/migration.sql
@@ -1,0 +1,73 @@
+-- CreateTable
+CREATE TABLE "World" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "Branch" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "worldId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "headCommitId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Branch_worldId_fkey" FOREIGN KEY ("worldId") REFERENCES "World" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Branch_headCommitId_fkey" FOREIGN KEY ("headCommitId") REFERENCES "Commit" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Commit" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "worldId" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "parentCommitId" TEXT,
+    "parentCommitId2" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Commit_worldId_fkey" FOREIGN KEY ("worldId") REFERENCES "World" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Commit_parentCommitId_fkey" FOREIGN KEY ("parentCommitId") REFERENCES "Commit" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Commit_parentCommitId2_fkey" FOREIGN KEY ("parentCommitId2") REFERENCES "Commit" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Unit" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "worldId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Unit_worldId_fkey" FOREIGN KEY ("worldId") REFERENCES "World" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "UnitSnapshot" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "commitId" TEXT NOT NULL,
+    "unitId" TEXT NOT NULL,
+    "contentJson" JSON NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "UnitSnapshot_commitId_fkey" FOREIGN KEY ("commitId") REFERENCES "Commit" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "UnitSnapshot_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "Unit" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "UnitState" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "branchId" TEXT NOT NULL,
+    "unitId" TEXT NOT NULL,
+    "contentJson" JSON NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "UnitState_branchId_fkey" FOREIGN KEY ("branchId") REFERENCES "Branch" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "UnitState_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "Unit" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Branch_worldId_name_key" ON "Branch"("worldId", "name");
+
+-- CreateIndex
+CREATE INDEX "UnitSnapshot_commitId_idx" ON "UnitSnapshot"("commitId");
+
+-- CreateIndex
+CREATE INDEX "UnitSnapshot_unitId_idx" ON "UnitSnapshot"("unitId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UnitState_branchId_unitId_key" ON "UnitState"("branchId", "unitId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,79 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model World {
+  id          String   @id
+  name        String
+  description String?
+  createdAt   DateTime @default(now())
+  branches    Branch[]
+  commits     Commit[]
+  units       Unit[]
+}
+
+model Branch {
+  id           String   @id
+  worldId      String
+  name         String
+  headCommitId String?
+  createdAt    DateTime @default(now())
+  world        World    @relation(fields: [worldId], references: [id])
+  headCommit   Commit?  @relation("BranchHead", fields: [headCommitId], references: [id])
+  unitStates   UnitState[]
+
+  @@unique([worldId, name])
+}
+
+model Commit {
+  id              String   @id
+  worldId         String
+  message         String
+  parentCommitId  String?
+  parentCommitId2 String?
+  createdAt       DateTime @default(now())
+  world           World    @relation(fields: [worldId], references: [id])
+  parentCommit    Commit?  @relation("CommitParent", fields: [parentCommitId], references: [id])
+  parentCommit2   Commit?  @relation("CommitParent2", fields: [parentCommitId2], references: [id])
+  snapshots       UnitSnapshot[]
+  branchesHead    Branch[] @relation("BranchHead")
+}
+
+model Unit {
+  id        String   @id
+  worldId   String
+  createdAt DateTime @default(now())
+  world     World    @relation(fields: [worldId], references: [id])
+  snapshots UnitSnapshot[]
+  states    UnitState[]
+}
+
+model UnitSnapshot {
+  id         String   @id
+  commitId   String
+  unitId     String
+  contentJson Json
+  createdAt  DateTime @default(now())
+  commit     Commit   @relation(fields: [commitId], references: [id])
+  unit       Unit     @relation(fields: [unitId], references: [id])
+
+  @@index([commitId])
+  @@index([unitId])
+}
+
+model UnitState {
+  id         String   @id
+  branchId   String
+  unitId     String
+  contentJson Json
+  createdAt  DateTime @default(now())
+  branch     Branch   @relation(fields: [branchId], references: [id])
+  unit       Unit     @relation(fields: [unitId], references: [id])
+
+  @@unique([branchId, unitId])
+}

--- a/src/core/__tests__/diff.test.ts
+++ b/src/core/__tests__/diff.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { diffUnits } from "../diff.js";
+import { UnitContent } from "../types.js";
+
+describe("diffUnits", () => {
+  it("outputs JSON Pointer paths for changed fields", () => {
+    const base: Record<string, UnitContent> = {
+      unitA: {
+        id: "unitA",
+        type: "npc",
+        title: "Old",
+        fields: { hp: 10, stats: { str: 1 } }
+      }
+    };
+
+    const next: Record<string, UnitContent> = {
+      unitA: {
+        id: "unitA",
+        type: "npc",
+        title: "New",
+        fields: { hp: 11, stats: { str: 2 } }
+      }
+    };
+
+    const changes = diffUnits(base, next);
+    const paths = changes.map((change) => change.path).sort();
+
+    expect(paths).toEqual(["/fields/hp", "/fields/stats/str", "/title"].sort());
+  });
+});

--- a/src/core/__tests__/merge.test.ts
+++ b/src/core/__tests__/merge.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { mergeUnits } from "../merge.js";
+import { UnitContent } from "../types.js";
+
+describe("mergeUnits", () => {
+  it("detects conflicts and merges non-conflicting fields", () => {
+    const base: Record<string, UnitContent> = {
+      unitA: {
+        id: "unitA",
+        type: "npc",
+        title: "Base",
+        fields: { hp: 10, mood: "calm" }
+      }
+    };
+
+    const ours: Record<string, UnitContent> = {
+      unitA: {
+        id: "unitA",
+        type: "npc",
+        title: "Ours",
+        fields: { hp: 12, mood: "calm" }
+      }
+    };
+
+    const theirs: Record<string, UnitContent> = {
+      unitA: {
+        id: "unitA",
+        type: "npc",
+        title: "Theirs",
+        fields: { hp: 10, mood: "angry" }
+      }
+    };
+
+    const result = mergeUnits(base, ours, theirs);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts).toEqual(
+      expect.arrayContaining([
+        {
+          unitId: "unitA",
+          path: "/title",
+          base: "Base",
+          ours: "Ours",
+          theirs: "Theirs"
+        }
+      ])
+    );
+
+    expect(result.mergedUnits.unitA.fields.hp).toBe(12);
+    expect(result.mergedUnits.unitA.fields.mood).toBe("angry");
+  });
+});

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -1,0 +1,65 @@
+import { DiffChange, UnitContent } from "./types.js";
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
+
+const isEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (isArray(a) && isArray(b)) {
+    return a.length === b.length && a.every((item, index) => isEqual(item, b[index]));
+  }
+  if (isObject(a) && isObject(b)) {
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+    for (const key of keys) {
+      if (!isEqual(a[key], b[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+};
+
+const joinPath = (base: string, key: string | number): string =>
+  base === "" ? `/${String(key)}` : `${base}/${String(key)}`;
+
+const diffValues = (from: unknown, to: unknown, path: string, changes: DiffChange[], unitId: string) => {
+  if (isEqual(from, to)) {
+    return;
+  }
+  if (isArray(from) && isArray(to)) {
+    const maxLength = Math.max(from.length, to.length);
+    for (let i = 0; i < maxLength; i += 1) {
+      diffValues(from[i], to[i], joinPath(path, i), changes, unitId);
+    }
+    return;
+  }
+  if (isObject(from) && isObject(to)) {
+    const keys = new Set([...Object.keys(from), ...Object.keys(to)]);
+    for (const key of keys) {
+      diffValues(from[key], to[key], joinPath(path, key), changes, unitId);
+    }
+    return;
+  }
+  changes.push({ unitId, path, from, to });
+};
+
+export const diffUnits = (
+  fromUnits: Record<string, UnitContent>,
+  toUnits: Record<string, UnitContent>
+): DiffChange[] => {
+  const changes: DiffChange[] = [];
+  const unitIds = new Set([...Object.keys(fromUnits), ...Object.keys(toUnits)]);
+
+  for (const unitId of unitIds) {
+    const fromUnit = fromUnits[unitId];
+    const toUnit = toUnits[unitId];
+    diffValues(fromUnit, toUnit, "", changes, unitId);
+  }
+
+  return changes;
+};

--- a/src/core/merge.ts
+++ b/src/core/merge.ts
@@ -1,0 +1,120 @@
+import { MergeConflict, MergeResult, UnitContent } from "./types.js";
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
+
+const isEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (isArray(a) && isArray(b)) {
+    return a.length === b.length && a.every((item, index) => isEqual(item, b[index]));
+  }
+  if (isObject(a) && isObject(b)) {
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+    for (const key of keys) {
+      if (!isEqual(a[key], b[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+};
+
+const joinPath = (base: string, key: string | number): string =>
+  base === "" ? `/${String(key)}` : `${base}/${String(key)}`;
+
+type MergeNodeResult = {
+  value: unknown;
+  conflicts: MergeConflict[];
+};
+
+const mergeValues = (
+  base: unknown,
+  ours: unknown,
+  theirs: unknown,
+  path: string,
+  unitId: string
+): MergeNodeResult => {
+  if (isEqual(ours, theirs)) {
+    return { value: ours, conflicts: [] };
+  }
+
+  if (isEqual(base, ours)) {
+    return { value: theirs, conflicts: [] };
+  }
+
+  if (isEqual(base, theirs)) {
+    return { value: ours, conflicts: [] };
+  }
+
+  if (isArray(base) && isArray(ours) && isArray(theirs)) {
+    const maxLength = Math.max(base.length, ours.length, theirs.length);
+    const merged: unknown[] = [];
+    const conflicts: MergeConflict[] = [];
+    for (let i = 0; i < maxLength; i += 1) {
+      const result = mergeValues(base[i], ours[i], theirs[i], joinPath(path, i), unitId);
+      merged[i] = result.value;
+      conflicts.push(...result.conflicts);
+    }
+    return { value: merged, conflicts };
+  }
+
+  if (isObject(base) && isObject(ours) && isObject(theirs)) {
+    const keys = new Set([...Object.keys(base), ...Object.keys(ours), ...Object.keys(theirs)]);
+    const merged: Record<string, unknown> = {};
+    const conflicts: MergeConflict[] = [];
+    for (const key of keys) {
+      const result = mergeValues(base[key], ours[key], theirs[key], joinPath(path, key), unitId);
+      if (result.value !== undefined) {
+        merged[key] = result.value;
+      }
+      conflicts.push(...result.conflicts);
+    }
+    return { value: merged, conflicts };
+  }
+
+  return {
+    value: ours,
+    conflicts: [
+      {
+        unitId,
+        path,
+        base,
+        ours,
+        theirs
+      }
+    ]
+  };
+};
+
+export const mergeUnits = (
+  baseUnits: Record<string, UnitContent>,
+  ourUnits: Record<string, UnitContent>,
+  theirUnits: Record<string, UnitContent>
+): MergeResult => {
+  const mergedUnits: Record<string, UnitContent> = {};
+  const conflicts: MergeConflict[] = [];
+  const unitIds = new Set([
+    ...Object.keys(baseUnits),
+    ...Object.keys(ourUnits),
+    ...Object.keys(theirUnits)
+  ]);
+
+  for (const unitId of unitIds) {
+    const base = baseUnits[unitId];
+    const ours = ourUnits[unitId];
+    const theirs = theirUnits[unitId];
+
+    const result = mergeValues(base, ours, theirs, "", unitId);
+    if (result.value !== undefined) {
+      mergedUnits[unitId] = result.value as UnitContent;
+    }
+    conflicts.push(...result.conflicts);
+  }
+
+  return { mergedUnits, conflicts };
+};

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,51 @@
+export type UnitContent = {
+  id: string;
+  type: string;
+  title: string;
+  fields: Record<string, unknown>;
+  refs?: Record<string, unknown>;
+};
+
+export type World = {
+  id: string;
+  name: string;
+  description?: string | null;
+  createdAt: Date;
+};
+
+export type Branch = {
+  id: string;
+  worldId: string;
+  name: string;
+  headCommitId?: string | null;
+  createdAt: Date;
+};
+
+export type Commit = {
+  id: string;
+  worldId: string;
+  message: string;
+  parentCommitId?: string | null;
+  parentCommitId2?: string | null;
+  createdAt: Date;
+};
+
+export type DiffChange = {
+  unitId: string;
+  path: string;
+  from: unknown;
+  to: unknown;
+};
+
+export type MergeConflict = {
+  unitId: string;
+  path: string;
+  base: unknown;
+  ours: unknown;
+  theirs: unknown;
+};
+
+export type MergeResult = {
+  mergedUnits: Record<string, UnitContent>;
+  conflicts: MergeConflict[];
+};

--- a/src/repo/branchRepo.ts
+++ b/src/repo/branchRepo.ts
@@ -1,0 +1,42 @@
+import { nanoid } from "nanoid";
+import { prisma } from "./prisma.js";
+
+export const getBranch = (worldId: string, name: string) =>
+  prisma.branch.findUnique({ where: { worldId_name: { worldId, name } } });
+
+export const createBranch = async (
+  worldId: string,
+  name: string,
+  sourceCommitId?: string | null
+) => {
+  const branch = await prisma.branch.create({
+    data: {
+      id: nanoid(),
+      worldId,
+      name,
+      headCommitId: sourceCommitId ?? null
+    }
+  });
+
+  if (sourceCommitId) {
+    const snapshots = await prisma.unitSnapshot.findMany({
+      where: { commitId: sourceCommitId }
+    });
+
+    if (snapshots.length > 0) {
+      await prisma.unitState.createMany({
+        data: snapshots.map((snapshot) => ({
+          id: nanoid(),
+          branchId: branch.id,
+          unitId: snapshot.unitId,
+          contentJson: snapshot.contentJson
+        }))
+      });
+    }
+  }
+
+  return branch;
+};
+
+export const updateBranchHead = (branchId: string, commitId: string) =>
+  prisma.branch.update({ where: { id: branchId }, data: { headCommitId: commitId } });

--- a/src/repo/commitRepo.ts
+++ b/src/repo/commitRepo.ts
@@ -1,0 +1,72 @@
+import { nanoid } from "nanoid";
+import { prisma } from "./prisma.js";
+
+export const createCommit = async (
+  worldId: string,
+  message: string,
+  parentCommitId?: string | null,
+  parentCommitId2?: string | null
+) => {
+  return prisma.commit.create({
+    data: {
+      id: nanoid(),
+      worldId,
+      message,
+      parentCommitId: parentCommitId ?? null,
+      parentCommitId2: parentCommitId2 ?? null
+    }
+  });
+};
+
+export const getCommit = (commitId: string) => prisma.commit.findUnique({ where: { id: commitId } });
+
+export const getCommitAncestors = async (commitId: string): Promise<Set<string>> => {
+  const visited = new Set<string>();
+  const stack = [commitId];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    const commit = await prisma.commit.findUnique({ where: { id: current } });
+    if (commit?.parentCommitId) {
+      stack.push(commit.parentCommitId);
+    }
+    if (commit?.parentCommitId2) {
+      stack.push(commit.parentCommitId2);
+    }
+  }
+
+  return visited;
+};
+
+export const findCommonAncestor = async (commitA?: string | null, commitB?: string | null) => {
+  if (!commitA || !commitB) {
+    return null;
+  }
+  const ancestorsA = await getCommitAncestors(commitA);
+  const queue = [commitB];
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    if (ancestorsA.has(current)) {
+      return current;
+    }
+    visited.add(current);
+    const commit = await prisma.commit.findUnique({ where: { id: current } });
+    if (commit?.parentCommitId) {
+      queue.push(commit.parentCommitId);
+    }
+    if (commit?.parentCommitId2) {
+      queue.push(commit.parentCommitId2);
+    }
+  }
+
+  return null;
+};

--- a/src/repo/prisma.ts
+++ b/src/repo/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();

--- a/src/repo/unitRepo.ts
+++ b/src/repo/unitRepo.ts
@@ -1,0 +1,51 @@
+import { nanoid } from "nanoid";
+import { UnitContent } from "../core/types.js";
+import { prisma } from "./prisma.js";
+
+export const upsertUnitState = async (
+  worldId: string,
+  branchId: string,
+  content: UnitContent
+) => {
+  const unit = await prisma.unit.upsert({
+    where: { id: content.id },
+    update: {},
+    create: {
+      id: content.id,
+      worldId
+    }
+  });
+
+  await prisma.unitState.upsert({
+    where: { branchId_unitId: { branchId, unitId: unit.id } },
+    create: {
+      id: nanoid(),
+      branchId,
+      unitId: unit.id,
+      contentJson: content
+    },
+    update: {
+      contentJson: content
+    }
+  });
+
+  return unit;
+};
+
+export const getBranchUnitStates = async (branchId: string) => {
+  const states = await prisma.unitState.findMany({ where: { branchId } });
+  const units: Record<string, UnitContent> = {};
+  for (const state of states) {
+    units[state.unitId] = state.contentJson as UnitContent;
+  }
+  return units;
+};
+
+export const getCommitUnitSnapshots = async (commitId: string) => {
+  const snapshots = await prisma.unitSnapshot.findMany({ where: { commitId } });
+  const units: Record<string, UnitContent> = {};
+  for (const snapshot of snapshots) {
+    units[snapshot.unitId] = snapshot.contentJson as UnitContent;
+  }
+  return units;
+};

--- a/src/repo/worldRepo.ts
+++ b/src/repo/worldRepo.ts
@@ -1,0 +1,24 @@
+import { nanoid } from "nanoid";
+import { prisma } from "./prisma.js";
+
+export const createWorld = async (name: string, description?: string | null) => {
+  const world = await prisma.world.create({
+    data: {
+      id: nanoid(),
+      name,
+      description
+    }
+  });
+
+  await prisma.branch.create({
+    data: {
+      id: nanoid(),
+      worldId: world.id,
+      name: "main"
+    }
+  });
+
+  return world;
+};
+
+export const getWorld = (worldId: string) => prisma.world.findUnique({ where: { id: worldId } });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,345 @@
+import Fastify from "fastify";
+import { z } from "zod";
+import { nanoid } from "nanoid";
+import { createWorld, getWorld } from "../repo/worldRepo.js";
+import { createBranch, getBranch, updateBranchHead } from "../repo/branchRepo.js";
+import { createCommit, findCommonAncestor } from "../repo/commitRepo.js";
+import { getBranchUnitStates, getCommitUnitSnapshots, upsertUnitState } from "../repo/unitRepo.js";
+import { diffUnits } from "../core/diff.js";
+import { mergeUnits } from "../core/merge.js";
+import { prisma } from "../repo/prisma.js";
+import { UnitContent } from "../core/types.js";
+
+const app = Fastify({ logger: true });
+
+const errorResponse = (code: string, message: string, details?: unknown) => ({
+  error: {
+    code,
+    message,
+    details
+  }
+});
+
+const parseRef = (value: string | undefined) => {
+  if (!value) {
+    return null;
+  }
+  const [type, id] = value.split(":");
+  if (!type || !id) {
+    return null;
+  }
+  if (type !== "branch" && type !== "commit") {
+    return null;
+  }
+  return { type, id } as { type: "branch" | "commit"; id: string };
+};
+
+const loadUnitsByRef = async (worldId: string, ref: { type: "branch" | "commit"; id: string }) => {
+  if (ref.type === "branch") {
+    const branch = await getBranch(worldId, ref.id);
+    if (!branch) {
+      throw errorResponse("NOT_FOUND", "Branch not found");
+    }
+    return getBranchUnitStates(branch.id);
+  }
+  return getCommitUnitSnapshots(ref.id);
+};
+
+const setValueAtPath = (target: Record<string, unknown>, path: string, value: unknown) => {
+  if (path === "") {
+    return value as Record<string, unknown>;
+  }
+  const parts = path.replace(/^\//, "").split("/");
+  let current: Record<string, unknown> = target;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const key = parts[i];
+    if (current[key] === undefined || typeof current[key] !== "object" || current[key] === null) {
+      current[key] = {};
+    }
+    current = current[key] as Record<string, unknown>;
+  }
+  current[parts[parts.length - 1]] = value as unknown;
+  return target;
+};
+
+const getValueAtPath = (target: Record<string, unknown> | undefined, path: string) => {
+  if (!target) {
+    return undefined;
+  }
+  if (path === "") {
+    return target;
+  }
+  const parts = path.replace(/^\//, "").split("/");
+  let current: unknown = target;
+  for (const part of parts) {
+    if (current === null || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+};
+
+app.post("/v1/worlds", async (request, reply) => {
+  const schema = z.object({
+    name: z.string().min(1),
+    description: z.string().optional()
+  });
+  const parsed = schema.safeParse(request.body);
+  if (!parsed.success) {
+    return reply.status(400).send(errorResponse("INVALID_INPUT", "Invalid request", parsed.error.format()));
+  }
+
+  const world = await createWorld(parsed.data.name, parsed.data.description);
+  return reply.status(201).send(world);
+});
+
+app.post("/v1/worlds/:worldId/branches", async (request, reply) => {
+  const schema = z.object({
+    name: z.string().min(1),
+    sourceBranch: z.string().optional(),
+    sourceCommitId: z.string().optional()
+  });
+  const paramsSchema = z.object({ worldId: z.string().min(1) });
+  const params = paramsSchema.safeParse(request.params);
+  const parsed = schema.safeParse(request.body);
+  if (!params.success || !parsed.success) {
+    return reply.status(400).send(errorResponse("INVALID_INPUT", "Invalid request"));
+  }
+  if (parsed.data.sourceBranch && parsed.data.sourceCommitId) {
+    return reply
+      .status(400)
+      .send(errorResponse("INVALID_INPUT", "Provide either sourceBranch or sourceCommitId"));
+  }
+
+  const world = await getWorld(params.data.worldId);
+  if (!world) {
+    return reply.status(404).send(errorResponse("NOT_FOUND", "World not found"));
+  }
+
+  let sourceCommitId: string | null | undefined = null;
+  if (parsed.data.sourceCommitId) {
+    sourceCommitId = parsed.data.sourceCommitId;
+  } else {
+    const sourceBranchName = parsed.data.sourceBranch ?? "main";
+    const sourceBranch = await getBranch(world.id, sourceBranchName);
+    if (!sourceBranch) {
+      return reply.status(404).send(errorResponse("NOT_FOUND", "Source branch not found"));
+    }
+    sourceCommitId = sourceBranch.headCommitId ?? null;
+  }
+
+  const branch = await createBranch(world.id, parsed.data.name, sourceCommitId);
+  return reply.status(201).send(branch);
+});
+
+app.post("/v1/worlds/:worldId/units", async (request, reply) => {
+  const schema = z.object({
+    branchName: z.string().min(1),
+    unit: z.object({
+      id: z.string().optional(),
+      type: z.string().min(1),
+      title: z.string().min(1),
+      fields: z.record(z.unknown()),
+      refs: z.record(z.unknown()).optional()
+    })
+  });
+  const paramsSchema = z.object({ worldId: z.string().min(1) });
+  const params = paramsSchema.safeParse(request.params);
+  const parsed = schema.safeParse(request.body);
+  if (!params.success || !parsed.success) {
+    return reply.status(400).send(errorResponse("INVALID_INPUT", "Invalid request"));
+  }
+
+  const world = await getWorld(params.data.worldId);
+  if (!world) {
+    return reply.status(404).send(errorResponse("NOT_FOUND", "World not found"));
+  }
+
+  const branch = await getBranch(world.id, parsed.data.branchName);
+  if (!branch) {
+    return reply.status(404).send(errorResponse("NOT_FOUND", "Branch not found"));
+  }
+
+  const unit: UnitContent = {
+    ...parsed.data.unit,
+    id: parsed.data.unit.id ?? nanoid()
+  };
+
+  await upsertUnitState(world.id, branch.id, unit);
+  return reply.status(201).send(unit);
+});
+
+app.post("/v1/worlds/:worldId/commits", async (request, reply) => {
+  const schema = z.object({
+    branchName: z.string().min(1),
+    message: z.string().min(1)
+  });
+  const paramsSchema = z.object({ worldId: z.string().min(1) });
+  const params = paramsSchema.safeParse(request.params);
+  const parsed = schema.safeParse(request.body);
+  if (!params.success || !parsed.success) {
+    return reply.status(400).send(errorResponse("INVALID_INPUT", "Invalid request"));
+  }
+
+  const world = await getWorld(params.data.worldId);
+  if (!world) {
+    return reply.status(404).send(errorResponse("NOT_FOUND", "World not found"));
+  }
+
+  const branch = await getBranch(world.id, parsed.data.branchName);
+  if (!branch) {
+    return reply.status(404).send(errorResponse("NOT_FOUND", "Branch not found"));
+  }
+
+  const commit = await createCommit(world.id, parsed.data.message, branch.headCommitId ?? null);
+  const states = await prisma.unitState.findMany({ where: { branchId: branch.id } });
+
+  if (states.length > 0) {
+    await prisma.unitSnapshot.createMany({
+      data: states.map((state) => ({
+        id: nanoid(),
+        commitId: commit.id,
+        unitId: state.unitId,
+        contentJson: state.contentJson
+      }))
+    });
+  }
+
+  await updateBranchHead(branch.id, commit.id);
+  return reply.status(201).send(commit);
+});
+
+app.get("/v1/worlds/:worldId/diff", async (request, reply) => {
+  const querySchema = z.object({ from: z.string(), to: z.string() });
+  const paramsSchema = z.object({ worldId: z.string().min(1) });
+  const params = paramsSchema.safeParse(request.params);
+  const parsed = querySchema.safeParse(request.query);
+  if (!params.success || !parsed.success) {
+    return reply.status(400).send(errorResponse("INVALID_INPUT", "Invalid request"));
+  }
+
+  const fromRef = parseRef(parsed.data.from);
+  const toRef = parseRef(parsed.data.to);
+  if (!fromRef || !toRef) {
+    return reply.status(400).send(errorResponse("INVALID_INPUT", "Invalid diff refs"));
+  }
+
+  try {
+    const fromUnits = await loadUnitsByRef(params.data.worldId, fromRef);
+    const toUnits = await loadUnitsByRef(params.data.worldId, toRef);
+    const changes = diffUnits(fromUnits, toUnits);
+    return reply.send({ changes });
+  } catch (error) {
+    return reply.status(404).send(error);
+  }
+});
+
+app.post("/v1/worlds/:worldId/merge", async (request, reply) => {
+  const schema = z.object({
+    oursBranch: z.string().min(1),
+    theirsBranch: z.string().min(1),
+    resolutions: z
+      .array(
+        z.object({
+          unitId: z.string().min(1),
+          path: z.string(),
+          choice: z.enum(["ours", "theirs", "manual"]),
+          value: z.unknown().optional()
+        })
+      )
+      .optional()
+  });
+  const paramsSchema = z.object({ worldId: z.string().min(1) });
+  const params = paramsSchema.safeParse(request.params);
+  const parsed = schema.safeParse(request.body);
+  if (!params.success || !parsed.success) {
+    return reply.status(400).send(errorResponse("INVALID_INPUT", "Invalid request"));
+  }
+
+  const world = await getWorld(params.data.worldId);
+  if (!world) {
+    return reply.status(404).send(errorResponse("NOT_FOUND", "World not found"));
+  }
+
+  const oursBranch = await getBranch(world.id, parsed.data.oursBranch);
+  const theirsBranch = await getBranch(world.id, parsed.data.theirsBranch);
+  if (!oursBranch || !theirsBranch) {
+    return reply.status(404).send(errorResponse("NOT_FOUND", "Branch not found"));
+  }
+
+  const baseCommitId = await findCommonAncestor(oursBranch.headCommitId, theirsBranch.headCommitId);
+  const baseUnits = baseCommitId ? await getCommitUnitSnapshots(baseCommitId) : {};
+  const oursUnits = oursBranch.headCommitId
+    ? await getCommitUnitSnapshots(oursBranch.headCommitId)
+    : {};
+  const theirsUnits = theirsBranch.headCommitId
+    ? await getCommitUnitSnapshots(theirsBranch.headCommitId)
+    : {};
+
+  const mergeResult = mergeUnits(baseUnits, oursUnits, theirsUnits);
+
+  if (mergeResult.conflicts.length > 0 && !parsed.data.resolutions) {
+    return reply.send({ conflicts: mergeResult.conflicts, previewMergedUnits: mergeResult.mergedUnits });
+  }
+
+  let resolvedUnits = { ...mergeResult.mergedUnits };
+  if (parsed.data.resolutions) {
+    for (const resolution of parsed.data.resolutions) {
+      const currentUnit = resolvedUnits[resolution.unitId] ?? ({} as UnitContent);
+      const sourceUnit =
+        resolution.choice === "ours"
+          ? (oursUnits[resolution.unitId] as Record<string, unknown> | undefined)
+          : resolution.choice === "theirs"
+            ? (theirsUnits[resolution.unitId] as Record<string, unknown> | undefined)
+            : (currentUnit as Record<string, unknown>);
+
+      const resolvedValue =
+        resolution.choice === "manual" ? resolution.value : getValueAtPath(sourceUnit, resolution.path);
+
+      if (resolution.path === "") {
+        resolvedUnits[resolution.unitId] = resolvedValue as UnitContent;
+      } else {
+        const updated = setValueAtPath({ ...(currentUnit as Record<string, unknown>) }, resolution.path, resolvedValue);
+        resolvedUnits[resolution.unitId] = updated as UnitContent;
+      }
+    }
+  }
+
+  const mergeCommit = await createCommit(
+    world.id,
+    `Merge ${oursBranch.name} <- ${theirsBranch.name}`,
+    oursBranch.headCommitId ?? null,
+    theirsBranch.headCommitId ?? null
+  );
+
+  const snapshotData = Object.values(resolvedUnits).map((unit) => ({
+    id: nanoid(),
+    commitId: mergeCommit.id,
+    unitId: unit.id,
+    contentJson: unit
+  }));
+
+  if (snapshotData.length > 0) {
+    await prisma.unitSnapshot.createMany({ data: snapshotData });
+  }
+
+  for (const unit of Object.values(resolvedUnits)) {
+    await upsertUnitState(world.id, oursBranch.id, unit);
+  }
+
+  await updateBranchHead(oursBranch.id, mergeCommit.id);
+
+  return reply.status(201).send({ mergeCommitId: mergeCommit.id });
+});
+
+const start = async () => {
+  try {
+    await app.listen({ port: 3000, host: "0.0.0.0" });
+  } catch (error) {
+    app.log.error(error);
+    process.exit(1);
+  }
+};
+
+start();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node"
+  }
+});


### PR DESCRIPTION
### Motivation

- Provide a minimal v0.1 prototype implementing the end-to-end WorldFork loop: create world → edit units → commit snapshots → branch → diff → merge/resolve → merge commit.
- Use snapshot-based storage so commits are immutable JSON snapshots per unit and branches maintain a working `UnitState` for edits.
- Offer deterministic, field-level JSON Pointer diffs and a simple three-way (base/ours/theirs) merge that reports conflicts for manual resolution.
- Expose the workflow over HTTP with validation and a documented reproducible curl demo for manual testing and iteration.

### Description

- Add project scaffold with `package.json` scripts (`dev`, `build`, `test`, `prisma:migrate`, `prisma:generate`) and TypeScript configuration for `tsx` development.
- Add Prisma schema and migration implementing `World`, `Branch`, `Commit`, `Unit`, `UnitSnapshot`, and `UnitState` models and use SQLite as the datasource.
- Implement core logic in `src/core` including `types.ts`, `diff.ts` (field-level, JSON Pointer style), and `merge.ts` (three-way merge producing `conflicts` and `mergedUnits`).
- Implement repository layer in `src/repo` and HTTP server in `src/server` with Fastify routes for worlds/branches/units/commits/diff/merge, `zod` validation, unified error format, conflict resolution flow, and README with curl walkthrough.

### Testing

- Added unit tests with Vitest under `src/core/__tests__/` that exercise `diffUnits` and `mergeUnits` behavior using representative cases.
- Tests were committed but not executed in this rollout; to run the tests locally use `npm run test` (which runs `vitest run`).
- The README documents how to start the server with `npm run dev` and run an end-to-end manual workflow including creating worlds, commits, branches, diffs, and merges.
- Prisma generation/migration helpers are provided via `npm run prisma:generate` and `npm run prisma:migrate` for local DB setup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d367d84a8832bb02f7fa22d21d482)