### PR TITLE
Serialize unit content when persisting to SQLite

### DIFF
--- a/src/repo/unitRepo.ts
+++ b/src/repo/unitRepo.ts
@@ -7,6 +7,7 @@ export const upsertUnitState = async (
   branchId: string,
   content: UnitContent
 ) => {
+  const contentJson = JSON.stringify(content);
   const unit = await prisma.unit.upsert({
     where: { id: content.id },
     update: {},
@@ -22,10 +23,10 @@ export const upsertUnitState = async (
       id: nanoid(),
       branchId,
       unitId: unit.id,
-      contentJson: content
+      contentJson
     },
     update: {
-      contentJson: content
+      contentJson
     }
   });
 
@@ -36,7 +37,7 @@ export const getBranchUnitStates = async (branchId: string) => {
   const states = await prisma.unitState.findMany({ where: { branchId } });
   const units: Record<string, UnitContent> = {};
   for (const state of states) {
-    units[state.unitId] = state.contentJson as UnitContent;
+    units[state.unitId] = JSON.parse(state.contentJson) as UnitContent;
   }
   return units;
 };
@@ -45,7 +46,7 @@ export const getCommitUnitSnapshots = async (commitId: string) => {
   const snapshots = await prisma.unitSnapshot.findMany({ where: { commitId } });
   const units: Record<string, UnitContent> = {};
   for (const snapshot of snapshots) {
-    units[snapshot.unitId] = snapshot.contentJson as UnitContent;
+    units[snapshot.unitId] = JSON.parse(snapshot.contentJson) as UnitContent;
   }
   return units;
 };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -317,7 +317,7 @@ app.post("/v1/worlds/:worldId/merge", async (request, reply) => {
     id: nanoid(),
     commitId: mergeCommit.id,
     unitId: unit.id,
-    contentJson: unit
+    contentJson: JSON.stringify(unit)
   }));
 
   if (snapshotData.length > 0) {


### PR DESCRIPTION
### Motivation

- Persist unit content as a serialized string so the SQLite-backed Prisma schema continues to use `String` fields for `contentJson` and avoid client-type mismatches.  
- Ensure HTTP handlers and repo functions no longer send raw objects to Prisma, which caused `Expected String, provided Object` errors.  
- Keep snapshots and branch states consistent by serializing on write and deserializing on read.  

### Description

- Serialize `UnitContent` with `JSON.stringify` before upserting `unitState` in `upsertUnitState` (`src/repo/unitRepo.ts`).  
- Parse stored JSON with `JSON.parse` when loading branch unit states and commit snapshots in `getBranchUnitStates` and `getCommitUnitSnapshots` (`src/repo/unitRepo.ts`).  
- Serialize merge commit snapshot payloads with `JSON.stringify` before `prisma.unitSnapshot.createMany` in the merge endpoint (`src/server/index.ts`).  
- Attempted to use Prisma `Json` type but reverted to `String` for `contentJson` to remain compatible with SQLite after a migration validation error.  

### Testing

- Ran `npx prisma migrate dev --name content-json` which failed validation due to SQLite not supporting the `Json` type (Prisma error P1012).  
- No unit/integration tests were executed as part of this change (`vitest` not run).  
- Manual code flow updated so writes now serialize and reads parse JSON; no automated verification executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5080ecc0832ba3b66043600fcc1b)